### PR TITLE
Update whatsapp_attachment.py

### DIFF
--- a/Whatsapp Automation/whatsapp_attachment.py
+++ b/Whatsapp Automation/whatsapp_attachment.py
@@ -21,5 +21,5 @@ image_box.send_keys(filepath)
 
 sleep(3)
 
-send_button = driver.find_element_by_xpath('//span[@data-icon="send-light"]')
+send_button = driver.find_element_by_xpath('//span[@data-icon="send"]')
 send_button.click()


### PR DESCRIPTION
Web whatsapp changed the name of the data icon from send-light to send . Made the necessary changes for the code to work  and resolved send-light element not found error .